### PR TITLE
Improvements and Fixes

### DIFF
--- a/src/backend/Cargo.toml
+++ b/src/backend/Cargo.toml
@@ -14,3 +14,4 @@ ic-cdk = "0.11.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 ic-stable-structures = "0.5.6"
+validator = { version = "0.15", features = ["derive"] }


### PR DESCRIPTION
## Fixes and Improvements

1. It is usually required for reports, especially health reports to store the initial/created time of the report as this may be needed later on. So, I've gone ahead and added a created_at field to store the time the report was made.
2.  I've noticed that anyone could update or delete an update which can be highly insecure as currently anyone can modify the content of an update which can lead to misleading and incorrect data being stored. So I've gone ahead and implemented an author field and authentication checks in the respective functions to ensure only the author of the crisis update can modify the update.
3. I've implemented input validations using the Validator crate to ensure that the input data when creating or updating a crisis update meets certain requirements so as to provide as much information as possible.
4. I've noticed that some of the queries function returned null whenever the function ended up not finding any update that meets the criteria set by the caller. This can lead to confusion, so I've gone ahead and implemented if statements to ensure that in case of no update being stored in the canister or no update meeting the criteria specified, an error message is returned to inform the user about the result of the function.
5. I've optimized the get_latest_crisis_update function to return the last element added instead of iterating over all elements to find the latest added crisis update.